### PR TITLE
Fix quote

### DIFF
--- a/os_computer_use/streaming.py
+++ b/os_computer_use/streaming.py
@@ -28,10 +28,11 @@ class DisplayClient:
         self.output_file = f"{output_dir}/output.mp4"
 
     async def start_display_client(self, stream_url, title="Sandbox", delay=0):
+        title = title.replace("'", "\\'")
         self.process = await asyncio.create_subprocess_shell(
             f"sleep {delay} && ffmpeg -reconnect 1 -i {stream_url} -c:v libx264 -preset fast -crf 23 "
             f"-c:a aac -b:a 128k -f mpegts -loglevel quiet - | tee {self.output_stream} | "
-            f"ffplay -autoexit -i -loglevel quiet -window_title '{title.replace("'", "\\'")}' -",
+            f"ffplay -autoexit -i -loglevel quiet -window_title '{title}' -",
             preexec_fn=os.setsid,
             stdin=asyncio.subprocess.DEVNULL,
         )


### PR DESCRIPTION
Fixes

```
  File "/mnt/c/Users/smart/Desktop/GD/open-computer-use/main.py", line 1, in <module>
    from os_computer_use.streaming import Sandbox, DisplayClient
  File "/mnt/c/Users/smart/Desktop/GD/open-computer-use/os_computer_use/streaming.py", line 34
    f"ffplay -autoexit -i -loglevel quiet -window_title '{title.replace("'", "\\'")}' -",
                                                                                        ^
SyntaxError: f-string: unmatched '('
```