### PR TITLE
Bugfix in llm_provider.py

### DIFF
--- a/os_computer_use/llm_provider.py
+++ b/os_computer_use/llm_provider.py
@@ -16,7 +16,7 @@ class LLMProvider:
     api_key = None
 
     # Mapping of model aliases
-    aliases = []
+    aliases = {}
 
     def __init__(self, model):
         # Validate base URL and API key


### PR DESCRIPTION
aliases is used like a dictionary and, therefore, must be initialized as a dictionary.