### PR TITLE
U sandbox screenshot

### DIFF
--- a/os_computer_use/sandbox_agent.py
+++ b/os_computer_use/sandbox_agent.py
@@ -70,7 +70,7 @@ class SandboxAgent:
         return filepath
 
     def take_screenshot(self):
-        file = self.sandbox.take_screenshot()
+        file = self.sandbox.screenshot()
         filename = self.save_image(file, "screenshot")
         logger.log(f"screenshot {filename}", "gray")
         self.latest_screenshot = filename


### PR DESCRIPTION
The latest version of the sandbox uses the “screenshot” method and the “take_screenshot” method displays an error